### PR TITLE
Update docblocks to specify ID rather than slug.

### DIFF
--- a/food-things-backend/src/food/controllers/food.controller.ts
+++ b/food-things-backend/src/food/controllers/food.controller.ts
@@ -48,9 +48,9 @@ export class FoodController {
   }
 
   /**
-   * A controller method to handle a PUT request to /food/:slug.
+   * A controller method to handle a PUT request to /food/:id.
    * @async
-   * @param slug The food item to update.
+   * @param food The food item to update.
    * @param foodData The data to update the food item with.
    * @returns The updated food item.
    */
@@ -66,7 +66,7 @@ export class FoodController {
   }
 
   /**
-   * A controller method to handle a GET request to /food/:slug.
+   * A controller method to handle a GET request to /food/:id.
    * @async
    * @param food The food item to retrieve.
    * @returns The requested food item.
@@ -80,7 +80,7 @@ export class FoodController {
   }
 
   /**
-   * A controller method to handle a DELETE request to /food/:slug.
+   * A controller method to handle a DELETE request to /food/:id.
    * @async
    * @param food The food item to delete.
    */


### PR DESCRIPTION
This branch was originally created to update the back-end to properly handle slugs for friendly URLs in the front-end. I have decided to take a different approach. See the ticket for further information.