### PR TITLE
Create checkbox component.

### DIFF
--- a/food-things-frontend/package.json
+++ b/food-things-frontend/package.json
@@ -7,7 +7,9 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "test": "vue-cli-service test:unit",
+    "test:v": "vue-cli-service test:unit --verbose",
     "test:watch": "vue-cli-service test:unit --watch",
+    "test:watch:v": "vue-cli-service test:unit --watch --verbose",
     "test:e2e": "vue-cli-service test:e2e --headless",
     "test:e2e:open": "vue-cli-service test:e2e"
   },

--- a/food-things-frontend/src/components/Checkbox.vue
+++ b/food-things-frontend/src/components/Checkbox.vue
@@ -1,0 +1,63 @@
+<template>
+  <div
+    :class="{ checked }"
+    class="checkbox"
+    tabindex="0"
+    @click="toggle"
+    @keyup.space="toggle"
+  >
+    {{ checked ? '✓' : '' }}
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Checkbox',
+
+  data() {
+    return {
+      checked: this.value || false,
+    }
+  },
+
+  props: {
+    value: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+
+  methods: {
+    toggle() {
+      this.checked = !this.checked
+      this.$emit('input', this.checked)
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+@import '../style/variables';
+
+.checkbox {
+  align-items: center;
+  background: $grey;
+  border-radius: 5px;
+  box-shadow: 0px 2px 2px $shadow;
+  color: $grey-light;
+  display: flex;
+  font-size: 21px;
+  height: 28px;
+  justify-content: center;
+  margin: 0.6em 0;
+  padding: 0.05em;
+  transition: background 0.15s;
+  user-select: none;
+  width: 28px;
+
+  &.checked {
+    background: $primary;
+  }
+}
+</style>

--- a/food-things-frontend/src/components/Checkbox.vue
+++ b/food-things-frontend/src/components/Checkbox.vue
@@ -50,7 +50,7 @@ export default {
   font-size: 21px;
   height: 28px;
   justify-content: center;
-  margin: 0.6em 0;
+  margin-bottom: 1em;
   padding: 0.05em;
   transition: background 0.15s;
   user-select: none;

--- a/food-things-frontend/src/main.js
+++ b/food-things-frontend/src/main.js
@@ -8,12 +8,14 @@ import PrimaryButton from '@/components/PrimaryButton.vue'
 import SecondaryButton from '@/components/SecondaryButton.vue'
 import Spinner from '@/components/Spinner.vue'
 import InputField from '@/components/InputField.vue'
+import Checkbox from '@/components/Checkbox.vue'
 
 Vue.config.productionTip = false
 Vue.component('PrimaryButton', PrimaryButton)
 Vue.component('SecondaryButton', SecondaryButton)
 Vue.component('InputField', InputField)
 Vue.component('Spinner', Spinner)
+Vue.component('Checkbox', Checkbox)
 
 new Vue({
   router,

--- a/food-things-frontend/src/views/Login.vue
+++ b/food-things-frontend/src/views/Login.vue
@@ -21,11 +21,11 @@
         icon="key"
       />
 
-      <InputField
-        v-model="remember"
-        type="checkbox"
-        label="Remember Me"
-      />
+      
+      <label>
+        Remember Me?
+        <Checkbox v-model="remember" />
+      </label>
 
       <PrimaryButton type="success" data-cy-login-btn>Login</PrimaryButton>
     </form>

--- a/food-things-frontend/tests/e2e/specs/login.js
+++ b/food-things-frontend/tests/e2e/specs/login.js
@@ -29,4 +29,14 @@ describe('Login', () => {
     cy.contains('Logout')
     cy.contains('Successfully logged in.').should('have.class', 'success')
   })
+
+  it('Should still be logged in after refreshing if you choose to be remembered.', () => {
+    cy.stubLogin()
+    cy.get('[name="username"]').type('jack')
+    cy.get('[name="password"]').type('jack')
+    cy.get('.checkbox').click()
+    cy.get('[data-cy-login-btn]').click()
+    cy.reload()
+    cy.contains('Logout')
+  })
 })

--- a/food-things-frontend/tests/e2e/support/commands.js
+++ b/food-things-frontend/tests/e2e/support/commands.js
@@ -13,6 +13,6 @@ Cypress.Commands.add('stubLogin', () => {
 Cypress.Commands.add('login', () => {
   cy.stubLogin()
   cy.visit('/login')
-  cy.get('[type="checkbox"]').click()
+  cy.get('.checkbox').click()
   cy.get('[data-cy-login-btn]').click()
 })

--- a/food-things-frontend/tests/unit/components/Checkbox.spec.js
+++ b/food-things-frontend/tests/unit/components/Checkbox.spec.js
@@ -1,0 +1,49 @@
+import { shallowMount } from '@vue/test-utils'
+import Checkbox from '@/components/Checkbox.vue'
+
+describe('Checkbox', () => {
+  it('Should render a div with the class of checkbox.', () => {
+    const wrapper = shallowMount(Checkbox)
+    expect(wrapper.contains('div.checkbox')).toBe(true)
+  })
+
+  it('Should add the class checked if a true value prop is passed.', () => {
+    const wrapper = shallowMount(Checkbox, {
+      propsData: {
+        value: true,
+      },
+    })
+
+    expect(wrapper.contains('div.checkbox.checked')).toBe(true)
+  })
+
+  it('Should not have the class checked if a false value prop is passed.', () => {
+    const wrapper = shallowMount(Checkbox, {
+      propsData: {
+        value: false,
+      },
+    })
+
+    expect(wrapper.contains('div.checkbox.checked')).toBe(false)
+  })
+
+  it('Should emit an event if it is clicked or space is used to toggle it.', () => {
+    const wrapper = shallowMount(Checkbox)
+
+    wrapper.trigger('click')
+    expect(wrapper.emitted()).toEqual({ input: [[true]] })
+
+    wrapper.trigger('keyup.space')
+    expect(wrapper.emitted()).toEqual({ input: [[true], [false]] })
+  })
+
+  it('Clicking or pressing space should toggle the checked class.', () => {
+    const wrapper = shallowMount(Checkbox)
+
+    wrapper.trigger('click')
+    expect(wrapper.contains('div.checkbox.checked')).toBe(true)
+
+    wrapper.trigger('keyup.space')
+    expect(wrapper.contains('div.checkbox.checked')).toBe(false)
+  })
+})

--- a/food-things-frontend/tests/unit/components/Checkbox.spec.js
+++ b/food-things-frontend/tests/unit/components/Checkbox.spec.js
@@ -27,6 +27,20 @@ describe('Checkbox', () => {
     expect(wrapper.contains('div.checkbox.checked')).toBe(false)
   })
 
+  it('Should render a tick if it is checked, or nothing if not.', () => {
+    const wrapper = shallowMount(Checkbox, {
+      propsData: {
+        value: true,
+      },
+    })
+
+    expect(wrapper.text()).toBe('✓')
+
+    wrapper.setData({ checked: false })
+
+    expect(wrapper.text()).toBe('')
+  })
+
   it('Should emit an event if it is clicked or space is used to toggle it.', () => {
     const wrapper = shallowMount(Checkbox)
 

--- a/food-things-frontend/tests/unit/components/global/index.js
+++ b/food-things-frontend/tests/unit/components/global/index.js
@@ -3,10 +3,12 @@ import PrimaryButton from '@/components/PrimaryButton.vue'
 import SecondaryButton from '@/components/SecondaryButton.vue'
 import Spinner from '@/components/Spinner.vue'
 import InputField from '@/components/InputField.vue'
+import Checkbox from '@/components/Checkbox.vue'
 
 export default function() {
   Vue.component('PrimaryButton', PrimaryButton)
   Vue.component('SecondaryButton', SecondaryButton)
   Vue.component('InputField', InputField)
   Vue.component('Spinner', Spinner)
+  Vue.component('Checkbox', Checkbox)
 }

--- a/food-things-frontend/tests/unit/views/Login.spec.js
+++ b/food-things-frontend/tests/unit/views/Login.spec.js
@@ -12,12 +12,12 @@ describe('Login', () => {
     expect(wrapper.is('div')).toBe(true)
   })
 
-  it('Should render three inputs of correct types.', () => {
+  it('Should render two inputs and a checkbox.', () => {
     const wrapper = shallowMount(Login, { mocks: { $store } })
 
     expect(wrapper.find('[type="text"]').exists()).toBe(true)
     expect(wrapper.find('[type="password"]').exists()).toBe(true)
-    expect(wrapper.find('[type="checkbox"]').exists()).toBe(true)
+    expect(wrapper.find('label vuecomponent-stub').exists()).toBe(true)
   })
 
   it('Should render a button with the type of success.', () => {


### PR DESCRIPTION
This PR creates a new checkbox component. This was created to allow greater customisation over the browser default checkbox input.

The checkbox component mimics browser behaviour as closely as possible. It has an outline style and can be toggled with space, for accessibility.